### PR TITLE
Potential fix for code scanning alert no. 16: Log entries created from user input

### DIFF
--- a/BookwormsOnline/Controllers/ErrorController.cs
+++ b/BookwormsOnline/Controllers/ErrorController.cs
@@ -19,10 +19,10 @@ namespace BookwormsOnline.Controllers
             switch (statusCode)
             {
                 case 404:
-                    _logger.LogWarning("404 Not Found: {Path}", HttpContext.Request.Path);
+                    _logger.LogWarning("404 Not Found: {Path}", HttpContext.Request.Path.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
                     return View("NotFound");
                 case 403:
-                    _logger.LogWarning("403 Forbidden: {Path}", HttpContext.Request.Path);
+                    _logger.LogWarning("403 Forbidden: {Path}", HttpContext.Request.Path.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
                     return View("Forbidden");
                 default:
                     _logger.LogWarning("Unexpected status code: {StatusCode}", statusCode);
@@ -34,7 +34,7 @@ namespace BookwormsOnline.Controllers
         [Route("Error/500")]
         public IActionResult ServerError()
         {
-            _logger.LogError("500 Internal Server Error: {Path}", HttpContext.Request.Path);
+            _logger.LogError("500 Internal Server Error: {Path}", HttpContext.Request.Path.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
             return View("Error");
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Elot-T/BookwormsOnline/security/code-scanning/16](https://github.com/Elot-T/BookwormsOnline/security/code-scanning/16)

To fix the problem, we need to sanitize the user input before logging it. Since the log entries are plain text, we should remove any newline characters from the user input to prevent log forging. We can use the `Replace` method to remove newline characters from `HttpContext.Request.Path` before logging it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
